### PR TITLE
Small grammatical changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,16 +169,16 @@ Occurs when you are given edit rights in the world.
 Occurs when someone joins the world.
 
 `[0] Integer` Id
-> The player's identifier.
+> The player's id.
 
 `[1] String` Username
 > The player's username.
 
 `[2] String` ConnectUserId
-> The player's unique user identifier.
+> The player's unique user id.
 
 `[3] Integer` Smiley
-> The player's smiley identifier.
+> The player's smiley id.
 
 `[4] Double` X
 > The x coordinate of the player's position.
@@ -217,20 +217,20 @@ Occurs when someone joins the world.
 > Value indicating whether the player is in moderator mode.
 
 `[16] Integer` Team
-> The player's team identifier.
+> The player's team id.
 > *See [Teams](#model-teams).*
 
 `[17] Integer` Aura Shape
-> The player's aura shape identifier.
+> The player's aura shape id.
 
 `[18] Integer` Aura Color
-> The player's aura color identifier.
+> The player's aura color id.
 
 `[19] Integer` Chat Color
 > The player's chat color.
 
 `[20] String` Badge
-> The player's badge identifier.
+> The player's badge id.
 > *See [Badges](#model-badges).*
 
 `[21] Boolean` Crew Member
@@ -244,7 +244,7 @@ Occurs when someone joins the world.
 Occurs when world was successfully added to a crew.
 
 `[0] String` Crew Id
-> The identifier of the crew to which the world was added.
+> The id of the crew to which the world was added.
 
 `[1] String` Crew Name
 > The name of the crew to which the world was added.
@@ -253,7 +253,7 @@ Occurs when world was successfully added to a crew.
 Occurs when a player toggles administrator mode.
 
 `[0] Integer` Player Id
-> The player's identifier.
+> The player's id.
 
 `[1] Boolean` Is In Administrator Mode
 > Value indicating whether the player is now in administrator mode.
@@ -268,19 +268,19 @@ Occurs when spectating in the world setting is changed.
 Occurs when a player changed their aura shape or color.
 
 `[0] Integer` Player Id
-> The player's identifier.
+> The player's id.
 
 `[1] Integer` Aura Shape
-> The aura shape identifier.
+> The aura shape id.
 
 `[2] Integer` Aura Color
-> The aura color identifier.
+> The aura color id.
 
 ### <a id="rm-autotext">"autotext"</a>
 Occurs when a player uses auto-text.
 
 `[0] Integer` Payer Id
-> The player's identifier.
+> The player's id.
 
 `[1] String` Auto-Text
 > The automatic text value.
@@ -292,7 +292,7 @@ Occurs when a player uses auto-text.
 Occurs when a block is placed in the world.
 
 `[0] Integer` Layer
-> The layer identifier.
+> The layer id.
 
 `[1] UInt` X
 > The x coordinate of the block's position.
@@ -301,10 +301,10 @@ Occurs when a block is placed in the world.
 > The y coordinate of the block's position.
 
 `[3] UInt` Block Id
-> The block identifier.
+> The block id.
 
 `[4] UInt` Player Id
-> The identifier of the player which placed this block.
+> The id of the player which placed this block.
 
 ### <a id="rm-backgroundColor">"backgroundColor"</a>
 Occurs when the background color of the world is changed.
@@ -317,10 +317,10 @@ Occurs when the background color of the world is changed.
 Occurs when a player changes their badge.
 
 `[0] Integer` Player Id
-> The player's identifier.
+> The player's id.
 
 `[1] String` Badge
-> The badge identifier.
+> The badge id.
 > *See [Badges](#model-badges).*
 
 ### <a id="rm-banned">"banned"</a>
@@ -336,13 +336,13 @@ Occurs when a block with number value is placed in the world.
 > The y coordinate of the block's position.
 
 `[2] UInt` Block Id
-> The block's identifier.
+> The block's id.
 
 `[3] UInt` Number Value
 > The number value.
 
 `[4] UInt` Player Id
-> The identifier of the player which placed this block.
+> The id of the player which placed this block.
 
 ### <a id="rm-br">"br"</a>
 Occurs when a morphable block is placed in the world.
@@ -354,13 +354,13 @@ Occurs when a morphable block is placed in the world.
 > The y coordinate of the block's position.
 
 `[3] UInt` Morph
-> The morph identifier.
+> The morph id.
 
 `[4] Integer` Layer
-> The layer identifier.
+> The layer id.
 
 `[5] UInt` Player Id
-> The identifier of the player which placed this block.
+> The id of the player which placed this block.
 
 ### <a id="rm-bs">"bs"</a>
 Occurs when a sound block is placed in the world.
@@ -372,13 +372,13 @@ Occurs when a sound block is placed in the world.
 > The y coordinate of the block's position.
 
 `[2] UInt` Block Id
-> The block identifier.
+> The block id.
 
 `[3] Integer` Sound Id
-> The sound identifier.
+> The sound id.
 
 `[4] UInt` Player Id
-> The identifier of the player which placed this block.
+> The id of the player which placed this block.
 
 
 
@@ -386,7 +386,7 @@ Occurs when a sound block is placed in the world.
 Occurs when a player's gold or blue coin count changes.
 
 `[0] Integer` Player Id
-> The player's identifier.
+> The player's id.
 
 `[1] Integer` Gold Coins
 > The amount of collected gold coins.
@@ -427,7 +427,7 @@ This message has 2 possible outcomes:
 Both outcomes are followed with list of rewards: 
 
 `[...] String` Id
-> The identifier of the reward.
+> The id of the reward.
 
 `[...] UInt` Quantity
 > The quantity of the reward.
@@ -442,10 +442,10 @@ Occurs when the world is cleared.
 > The height of the world.
 
 `[2] UInt` Border Block Id
-> The identifier of the block used as a world border.
+> The id of the block used as a world border.
 
 `[3] UInt` Fill Block Id
-> The identifier of the block used to fill the world.
+> The id of the block used to fill the world.
 
 ### <a id="rm-completedLevel">"completedLevel"</a>
 Occurs when completing a world by touching win trophy.  
@@ -474,7 +474,7 @@ Occurs when a player receives or loses edit rights.
 **NOTE:** You can only recieve this message if you are the world owner.
 
 `[0] Integer` Player Id
-> The player's identifier.
+> The player's id.
 
 `[1] Boolean` Can Edit
 > Value indicating whether the player is now allowed to edit in the world.
@@ -483,10 +483,10 @@ Occurs when a player receives or loses edit rights.
 Occurs when a player gains or looses an effect.
 
 `[0] Integer` Player Id
-> The player's identifier.
+> The player's id.
 
 `[1] Integer` Effect
-> The effect's identifier.
+> The effect's id.
 > *See [Effects](#model-effects).*
 
 `[2] Boolean` Enabled
@@ -513,10 +513,10 @@ Occurs when effect limits are changed.
 Occurs when someone changes their smiley.
 
 `[0] Integer` Player Id
-> The player's identifier.
+> The player's id.
 
 `[1] Integer` Smiley
-> The smiley identifier.
+> The smiley id.
 
 ### <a id="rm-favorited">"favorited"</a>
 Occurs when you successfully favorited the world.
@@ -525,19 +525,19 @@ Occurs when you successfully favorited the world.
 Occurs when you are given a magic brick package.
 
 `[0] String` Package
-> The identifier of the magic brick package.
+> The id of the magic brick package.
 
 ### <a id="rm-givemagicsmiley">"givemagicsmiley"</a>
 Occurs when you are given magic smiley.
 
 `[0] String` Smiley
-> The identifier of the magic smiley.
+> The id of the magic smiley.
 
 ### <a id="rm-god">"god"</a>
 Occurs when a player toggles god mode.
 
 `[0] Integer` Player Id
-> The player's identifier.
+> The player's id.
 
 `[1] Boolean` Is In God Mode
 > Value indicating whether this player is now in god mode.
@@ -547,7 +547,7 @@ Occurs when a player toggles god mode.
 Occurs when a player touches a key or timed doors change their state.
 
 `[0] Integer` Player Id
-> The player's identifier.
+> The player's id.
 
 `[1] String` Key
 > The name of the key (or timed door).
@@ -598,16 +598,16 @@ Contains world information such as world name and the world content.
 > The amount of likes.
 
 `[5] Integer` Player Id
-> The player's identifier.
+> The player's id.
 
 `[6] Integer` Smiley
-> The player's smiley identifier.
+> The player's smiley id.
 
 `[7] Integer` Aura Shape
-> The player's aura shape identifier.
+> The player's aura shape id.
 
 `[8] Integer` Aura Color
-> The player's aura color identifier.
+> The player's aura color id.
 
 `[9] Boolean` Gold Smiley Border
 > Value indicating whether the player is wearing gold smiley border.
@@ -671,7 +671,7 @@ Contains world information such as world name and the world content.
 > Value indicating whether this world is part of a campaign.
 
 `[29] String` Crew Id
-> The identifier of the crew to which belongs this world.
+> The id of the crew to which belongs this world.
 
 `[30] String` Crew Name
 > The name of the crew to which belongs this world.
@@ -684,7 +684,7 @@ Contains world information such as world name and the world content.
 > *See [Crew World Status](#model-crew-status).*
 
 `[33] String` Badge
-> The player's badge identifier.
+> The player's badge id.
 > *See [Badges](#model-badges).*
 
 `[34] Boolean` Is Crew Member
@@ -736,20 +736,20 @@ Additional parameters received when this campaign world is unlocked:
 Occurs when a player collects gold crown.
 
 `[0] Integer` Player Id
-> The player's identifier.  
+> The player's id.  
 > **NOTE:** Set to `-1` if there is no player with a crown.
 
 ### <a id="rm-kill">"kill"</a>
 Occurs when a player is killed due to expired effect or /kill, /killall commands.
 
 `[0] Integer` Player Id
-> The player's identifier.
+> The player's id.
 
 ### <a id="rm-ks">"ks"</a>
 Occurs when someone receives a silver crown.
 
 `[0] Integer` Player Id
-> The player's identifier.
+> The player's id.
 
 
 ### <a id="rm-lb">"lb"</a>
@@ -762,7 +762,7 @@ Occurs when someone places a label block.
 > The y coordinate of the block's position.
 
 `[2] Integer` Block Id
-> The identifier of the block.
+> The id of the block.
 
 `[3] String` Text
 > The text.
@@ -771,13 +771,13 @@ Occurs when someone places a label block.
 > The color of the text.
 
 `[5] UInt` Player Id
-> The identifier of the player which placed this block.
+> The id of the player which placed this block.
 
 ### <a id="rm-left">"left"</a>
 Occurs when someone leaves the world.
 
 `[0] Integer` Player Id
-> The player's identifier.
+> The player's id.
 
 ### <a id="rm-liked">"liked"</a>
 Occurs when you liked the world.
@@ -796,7 +796,7 @@ Occurs when you lose edit rights.
 Occurs when a user moves.
 
 `[0] Integer` Player Id
-> The player's identifier.
+> The player's id.
 
 `[1] Double` X
 > The x coordinate of the player's position.
@@ -843,7 +843,7 @@ Occurs when the minimap is toggled.
 Occurs when a player toggles moderator mode.
 
 `[0] Integer` Player Id
-> The player's identifier.
+> The player's id.
 
 `[1] Boolean` Is In Moderator Mode
 > Value indicating whether the player is now in moderator mode.
@@ -852,7 +852,7 @@ Occurs when a player toggles moderator mode.
 Occurs when you muted or un-umted a player.
 
 `[0] Integer` Player Id
-> The player's identifier.
+> The player's id.
 
 `[1] Boolean` Muted
 > Value indicating whether the player is now muted.
@@ -862,10 +862,10 @@ Occurs when you muted or un-umted a player.
 Occurs when a player touches a purple switch.
 
 `[0] Integer` Player Id
-> The player's identifier.
+> The player's id.
 
 `[1] Integer` Switch Id
-> The switch identifier.
+> The switch id.
 
 `[2] Integer` Enabled
 > Value indicating the state of the switch.  
@@ -875,7 +875,7 @@ Occurs when a player touches a purple switch.
 Occurs after join. Contains information about initial switch states.
 
 `[0] Integer` Player Id
-> The player's identifier.
+> The player's id.
 
 `[1] ByteArray` Switch States
 > The byte array describing switch states.
@@ -890,19 +890,19 @@ Occurs when a portal is placed in the world.
 > The y coordinate of the block's position.
 
 `[2] UInt` Block Id
-> The block identifier.
+> The block id.
 
 `[3] UInt` Portal Rotation
 > The portal rotation.
 
 `[4] UInt` Portal Id
-> The portal identifier.
+> The portal id.
 
 `[5] UInt` Portal Target
-> The portal target identifier.
+> The portal target id.
 
 `[6] Integer` Player Id
-> The identifier of the player which placed this block.
+> The id of the player which placed this block.
 
 
 ### <a id="rm-reset">"reset"</a>
@@ -921,7 +921,7 @@ Occurs when world is reverted to the last save using the /loadlevel command.
 Occurs when your campaign progress is restored.
 
 `[0] Integer` Player Id
-> The player's identifier.
+> The player's id.
 
 `[1] Double` X
 > The x coordinate of the player's position.
@@ -985,7 +985,7 @@ Occurs when you saved the world.
 Occurs when a player sends a chat message.
 
 `[0 Integer` Player Id
-> The player's identifier.
+> The player's id.
 
 `[1] String` Text
 > The chat message text.
@@ -1017,7 +1017,7 @@ Occurs when a key deactivates or timed doors change their state.
 Occurs when someone toggles the gold smiley border.
 
 `[0] Integer` Player Id
-> The player's identifier.
+> The player's id.
 
 `[1] Boolean` Gold Smiley Border
 > Value indicating whether the player is wearing gold smiley border.
@@ -1027,10 +1027,10 @@ Occurs when someone toggles the gold smiley border.
 Occurs when a player changes their team.
 
 `[0] Integer` Player Id
-> The player's identifier.
+> The player's id.
 
 `[1] Integer` Team
-> The team identifier.
+> The team id.
 > *See [Teams](#model-teams).*
 
 ### <a id="rm-tele">"tele"</a>
@@ -1042,7 +1042,7 @@ Occurs when multiple players are teleported or respawns (including death.)
 Repeated for each teleported player:
 
 `[...] Integer` Player Id
-> The player's identifier.
+> The player's id.
 
 `[...] Double` X
 > The x coordinate of the player's respawn position.
@@ -1057,7 +1057,7 @@ Repeated for each teleported player:
 Occurs when a player is teleported to another location.
 
 `[0] Integer` Player Id
-> The player's identifier.
+> The player's id.
 
 `[1] Integer` X
 > The x coordinate of the player's position.
@@ -1078,7 +1078,7 @@ Occurs as a response to the ["time"](#sm-time) send message.
 Occurs when a player received or lost ability to toggle god mode.
 
 `[0] Integer` Player Id
-> The player's identifier.
+> The player's id.
 
 `[1] Boolean` Can Toggle God
 > Value indicating whether the player can now toggle god mode.
@@ -1093,7 +1093,7 @@ Occurs when a sign block is placed in the world.
 > The y coordinate of the block's position.
 
 `[2] UInt` Block Id
-> The block identifier.
+> The block id.
 
 `[3] String` Text
 > The text.
@@ -1102,7 +1102,7 @@ Occurs when a sign block is placed in the world.
 > The type of the sign.
 
 `[5] UInt` Player Id
-> The identifier of the player which placed this block.
+> The id of the player which placed this block.
 
 ___
 
@@ -1147,13 +1147,13 @@ Occurs when a world portal is placed in the world.
 > The y coordinate of the block's position.
 
 `[2] UInt` Block Id
-> The block identifier.
+> The block id.
 
 `[3] String` Target
 > The target of the world portal.
 
 `[4] UInt` Player Id
-> The identifier of the player which placed this block.
+> The id of the player which placed this block.
 
 ### <a id="rm-write">"write"</a>
 Occurs when a non-player message is received (system messages, etc.)
@@ -1183,16 +1183,16 @@ Sent to toggle administrator mode.
 Sent to change aura shape and/or color.
 
 `[0] Integer` Aura Shape
-> The aura shape identifier.
+> The aura shape id.
 
 `[1] Integer` Aura Color
-> The aura color identifier.
+> The aura color id.
 
 ### <a id="sm-autosay">"autosay"</a>
 Sent to use auto-say message.
 
 `[0] Integer` Auto-Text
-> The auto-text message identifier.
+> The auto-text message id.
 > *See [Auto Text](#model-auto-text).*
 
 
@@ -1200,7 +1200,7 @@ Sent to use auto-say message.
 Sent to place a block in the world.
 
 `[0] Integer` Layer
-> The layer identifier.
+> The layer id.
 
 `[1] Integer` X
 > The x coordinate of the block's position.
@@ -1209,14 +1209,14 @@ Sent to place a block in the world.
 > The y coordinate of the block's position.
 
 `[3] Integer` Block Id
-> The block identifier.
+> The block id.
 
 Additional arguments:
 
 - For sound blocks:
 
 `[4] Integer` Sound Id
-> The sound identifier.
+> The sound id.
 
 - For admin label:
 
@@ -1237,10 +1237,10 @@ Additional arguments:
 > The portal rotation.
 
 `[5] Integer` Portal Id
-> The portal identifier.
+> The portal id.
 
 `[6] Integer` Portal Target
-> The portal target identifier.
+> The portal target id.
 
 - For world portal:
 
@@ -1293,7 +1293,7 @@ Sent to change checkpoint position.
 Sent to change the badge.
 
 `[0] String` Badge
-> The badge identifier.
+> The badge id.
 > *See [Badges](#model-badges).*
 
 ### <a id="sm-clear">"clear"</a>
@@ -1333,7 +1333,7 @@ Sent to activate or deactivate an effect.
 > The y coordinate of the effect's position.
 
 `[2] Integer` Effect
-> The effect identifier.
+> The effect id.
 > *See [Effects](#model-effects).*
 
 ___
@@ -1428,7 +1428,7 @@ Sent to move.
 > Value indicating whether the player has just pressed down space-bar.
 
 `[11] Integer` Tick Id
-> The player's current tick identifier.
+> The player's current tick id.
 
 ### <a id="sm-mod">"mod"</a>
 Sent to toggle moderator mode.
@@ -1458,7 +1458,7 @@ Sent to activate a key.
 Sent to change the purple switch state.
 
 `[0] UInt` Switch Id
-> The switch identifier.
+> The switch id.
 
 `[1] Integer` Enabled
 > Value indicating the state of the switch. 1 = active, 0 = disabled.
@@ -1470,7 +1470,7 @@ Sent to reject add to crew request.
 Sent to request adding of the world to a crew.
 
 `[0] String` Crew Id
-> The crew identifier.
+> The crew id.
 
 ### <a id="sm-reset">"reset"</a>
 Sent to reset progress.
@@ -1550,7 +1550,7 @@ Sent to change the zombie limit.
 Sent to change smiley.
 
 `[0] Integer` Smiley
-> The smiley identifier.
+> The smiley id.
 
 ### <a id="sm-smileyGoldBorder">"smileyGoldBorder"</a>
 Sent to enable or disable gold smiley border.
@@ -1578,10 +1578,10 @@ Sent to request ["time"](#rm-time) message response.
 Sent to touch other player transferring effects.
 
 `[0] Integer` Player Id
-> The touched player's identifier.
+> The touched player's id.
 
 `[1] Integer` Effect
-> The effect identifier.
+> The effect id.
 
 
 ### <a id="sm-unfavorite">"unfavorite"</a>

--- a/README.md
+++ b/README.md
@@ -554,7 +554,7 @@ Occurs when a player touches a key or timed doors change their state.
 > *See [Keys](#model-keys).*
 
 ### <a id="rm-hideLobby">"hideLobby"</a>
-Occurs when "world hidden in the lobby setting" is toggled.
+Occurs when "world hidden in the lobby setting" is changed.
 
 `[0] Boolean` Hidden
 > Value indicating whether the world is hidden from the lobby and profile.
@@ -783,7 +783,7 @@ Occurs when someone leaves the world.
 Occurs when you liked the world.
 
 ### <a id="rm-lobbyPreviewEnabled">"lobbyPreviewEnabled"</a>
-Occurs when lobby preview is toggled.
+Occurs when lobby preview is enabled or disabled.
 
 `[0] Boolean` Enabled
 > Value indicating whether the lobby preview is now enabled.
@@ -834,7 +834,7 @@ Occurs when a user moves.
 Occurs when you are given a magic reward.
 
 ### <a id="rm-minimapEnabled">"minimapEnabled"</a>
-Occurs when the minimap is toggled.
+Occurs when the minimap is changed.
 
 `[0] Boolean` Minimap Enabled
 > Value indicating whether the minimap is now enabled.
@@ -972,7 +972,7 @@ Occurs when the world description is changed.
 > The world description.
 
 ### <a id="rm-roomVisible">"roomVisible"</a>
-Occurs when the world accessibility is toggled.
+Occurs when the world accessibility is changed.
 
 `[0] Boolean` Accessible
 > Value indicating whether the world is now accessible by other players.
@@ -1014,7 +1014,7 @@ Occurs when a key deactivates or timed doors change their state.
 > *See [Keys](#model-keys).*
 
 ### <a id="rm-smileyGoldBorder">"smileyGoldBorder"</a>
-Occurs when someone toggles the gold smiley border.
+Occurs when someone enables or disables the gold smiley border.
 
 `[0] Integer` Player Id
 > The player's id.

--- a/README.md
+++ b/README.md
@@ -148,13 +148,13 @@ Version = 206
 
 # <a id="room-types">Room Types</a>
 ```
-Normal      = EverybodyeditsXXX
-Beta        = BetaXXX
-Lobby       = LobbyXXX
-Crew Lobby  = CrewLobbyXXX
-Guest Lobby = GuestLobbyXXX
+Normal      = Everybodyedits{version}
+Beta        = Beta{version}
+Lobby       = Lobby{version}
+Crew Lobby  = CrewLobby{version}
+Guest Lobby = GuestLobby{version}
 
-(Replace XXX with the current version)
+(Replace {version} with the current version)
 ```
 ___
 
@@ -162,6 +162,8 @@ ___
 
 ### <a id="rm-access">"access"</a>
 Occurs when you are given edit rights in the world.
+
+*(This event does not contain any other information.)*
 
 ### <a id="rm-add">"add"</a>
 Occurs when someone joins the world.
@@ -236,7 +238,7 @@ Occurs when someone joins the world.
 
 `[22] Boolean` Can Edit
 > Value indicating whether the player can edit in this world.  
-> **NOTE:** This is received only by the world owner.
+> **NOTE:** This can only be received by the world owner.
 
 ### <a id="rm-addedToCrew">"addedToCrew"</a>
 Occurs when world was successfully added to a crew.
@@ -284,7 +286,7 @@ Occurs when a player uses auto-text.
 > The automatic text value.
 > *See [Auto Text](#model-auto-text).*
 
-___
+
 
 ### <a id="rm-b">"b"</a>
 Occurs when a block is placed in the world.
@@ -309,10 +311,10 @@ Occurs when the background color of the world is changed.
 
 `[0] UInt` Color
 > The color of the background.
-> **NOTE:** Transparent color means that the custom background color is disabled.
+> **NOTE:** transparent color means the custom background color is disabled.
 
 ### <a id="rm-badgeChange">"badgeChange"</a>
-Occurs when a player changes badge.
+Occurs when a player changes their badge.
 
 `[0] Integer` Player Id
 > The player's identifier.
@@ -378,7 +380,7 @@ Occurs when a sound block is placed in the world.
 `[4] UInt` Player Id
 > The identifier of the player which placed this block.
 
-___
+
 
 ### <a id="rm-c">"c"</a>
 Occurs when a player's gold or blue coin count changes.
@@ -422,7 +424,7 @@ This message has 2 possible outcomes:
 `[1] String` World URL
 > The image URL of the next world in the campaign.
 
-Both of these outcomes are followed with list of rewards described as follows:
+Both outcomes are followed with list of rewards: 
 
 `[...] String` Id
 > The identifier of the reward.
@@ -447,7 +449,7 @@ Occurs when the world is cleared.
 
 ### <a id="rm-completedLevel">"completedLevel"</a>
 Occurs when completing a world by touching win trophy.  
-**NOTE:** If player received campaign rewards, ["campaignRewards"](#rm-campaignRewards) message is received instead.
+**NOTE:** If player received campaign rewards, the ["campaignRewards"](#rm-campaignRewards) message is received instead.
 
 ### <a id="rm-crewAddRequest">"crewAddRequest"</a>
 Occurs when a player requests to add the world to their crew.
@@ -465,11 +467,11 @@ Occurs when an attempt to request adding of the world to a crew didn't succeed.
 `[0] String` Reason
 > The reason of the failure.
 
-___
+
 
 ### <a id="rm-editRights">"editRights"</a>
 Occurs when a player receives or loses edit rights.
-**NOTE:** You receive this even only if you are the owner of the world.
+**NOTE:** You can only recieve this message if you are the world owner.
 
 `[0] Integer` Player Id
 > The player's identifier.
@@ -490,12 +492,10 @@ Occurs when a player gains or looses an effect.
 `[2] Boolean` Enabled
 > Value indicating whether the effect is enabled.
 
-Conditional parameters:
+`[3] Double` Argument *(optional)*
+> The optional argument of the effect (time left, number of jumps, etc.)
 
-`[3] Double` Argument
-> The optional argument of the effect. (time left, number of jumps, etc.)
-
-`[4] Integer` Duration
+`[4] Integer` Duration *(optional)*
 > The duration of the effect.
 
 ### <a id="rm-effectlimits">"effectlimits"</a>
@@ -507,7 +507,7 @@ Occurs when effect limits are changed.
 `[1] Integer` Zombie Limit
 > The zombie limit.
 
-___
+
 
 ### <a id="rm-face">"face"</a>
 Occurs when someone changes their smiley.
@@ -520,8 +520,6 @@ Occurs when someone changes their smiley.
 
 ### <a id="rm-favorited">"favorited"</a>
 Occurs when you successfully favorited the world.
-
-___
 
 ### <a id="rm-givemagicbrickpackage">"givemagicbrickpackage"</a>
 Occurs when you are given a magic brick package.
@@ -544,7 +542,6 @@ Occurs when a player toggles god mode.
 `[1] Boolean` Is In God Mode
 > Value indicating whether this player is now in god mode.
 
-___
 
 ### <a id="rm-hide">"hide"</a>
 Occurs when a player touches a key or timed doors change their state.
@@ -557,15 +554,14 @@ Occurs when a player touches a key or timed doors change their state.
 > *See [Keys](#model-keys).*
 
 ### <a id="rm-hideLobby">"hideLobby"</a>
-Occurs when world hidden in the lobby setting is changed.
+Occurs when "world hidden in the lobby setting" is toggled.
 
 `[0] Boolean` Hidden
-> Value indicating whether the world is now hidden from the lobby and profile.
+> Value indicating whether the world is hidden from the lobby and profile.
 
-___
 
 ### <a id="rm-info">"info"</a>
-Occurs when the server sends information pertaining to low-level functions like (a) you were kicked or (b) the room is full or (c) rate limit exceeded.
+Occurs when the server sends information like (a) you were kicked or (b) the room is full or (c) rate limit exceeded.
 
 `[0] String` Title
 > The title of the message.
@@ -574,7 +570,7 @@ Occurs when the server sends information pertaining to low-level functions like 
 > The text of the message.
 
 ### <a id="rm-info2">"info2"</a>
-Occurs when the server sends low priority information that can be displayed in non-invasive pop-up.
+Occurs when the server sends low priority information that can be displayed in an non-invasive pop-up.
 
 `[0] String` Title
 > The title of the message.
@@ -590,7 +586,7 @@ Contains world information such as world name and the world content.
 > The username of the world owner.
 
 `[1] String` World Name
-> The name of the world.
+> The world name.
 
 `[2] Integer` Plays
 > The amount of plays.
@@ -712,7 +708,6 @@ Contains world information such as world name and the world content.
 ### <a id="rm-init2">"init2"</a>
 Occurs when joining world is completed.
 
-___
 
 ### <a id="rm-joinCampaign">"joinCampaign"</a>
 Occurs when player joins a campaign world.
@@ -736,7 +731,6 @@ Additional parameters received when this campaign world is unlocked:
 `[4] Integer` Tiers
 > The amount of tiers in the campaign.
 
-___
 
 ### <a id="rm-k">"k"</a>
 Occurs when a player collects gold crown.
@@ -757,7 +751,6 @@ Occurs when someone receives a silver crown.
 `[0] Integer` Player Id
 > The player's identifier.
 
-___
 
 ### <a id="rm-lb">"lb"</a>
 Occurs when someone places a label block.
@@ -787,10 +780,10 @@ Occurs when someone leaves the world.
 > The player's identifier.
 
 ### <a id="rm-liked">"liked"</a>
-Occurs when you successfully liked the world.
+Occurs when you liked the world.
 
 ### <a id="rm-lobbyPreviewEnabled">"lobbyPreviewEnabled"</a>
-Occurs when lobby preview is enabled or disabled.
+Occurs when lobby preview is toggled.
 
 `[0] Boolean` Enabled
 > Value indicating whether the lobby preview is now enabled.
@@ -798,10 +791,9 @@ Occurs when lobby preview is enabled or disabled.
 ### <a id="rm-lostaccess">"lostaccess"</a>
 Occurs when you lose edit rights.
 
-___
 
 ### <a id="rm-m">"m"</a>
-Occurs when someone moves.
+Occurs when a user moves.
 
 `[0] Integer` Player Id
 > The player's identifier.
@@ -839,10 +831,10 @@ Occurs when someone moves.
 > Value indicating whether the player has just pressed down space-bar.
 
 ### <a id="rm-magic">"magic"</a>
-Occurs when you are given magic reward.
+Occurs when you are given a magic reward.
 
 ### <a id="rm-minimapEnabled">"minimapEnabled"</a>
-Occurs when the minimap is enabled or disabled.
+Occurs when the minimap is toggled.
 
 `[0] Boolean` Minimap Enabled
 > Value indicating whether the minimap is now enabled.
@@ -857,7 +849,7 @@ Occurs when a player toggles moderator mode.
 > Value indicating whether the player is now in moderator mode.
 
 ### <a id="rm-muted">"muted"</a>
-Occurs when you successfully muted or un-umted someone.
+Occurs when you muted or un-umted a player.
 
 `[0] Integer` Player Id
 > The player's identifier.
@@ -865,10 +857,9 @@ Occurs when you successfully muted or un-umted someone.
 `[1] Boolean` Muted
 > Value indicating whether the player is now muted.
 
-___
 
 ### <a id="rm-ps">"ps"</a>
-Occurs when someone touches purple switch.
+Occurs when a player touches a purple switch.
 
 `[0] Integer` Player Id
 > The player's identifier.
@@ -913,10 +904,9 @@ Occurs when a portal is placed in the world.
 `[6] Integer` Player Id
 > The identifier of the player which placed this block.
 
-___
 
 ### <a id="rm-reset">"reset"</a>
-Occurs when world is reverted to the last save using /loadlevel command.
+Occurs when world is reverted to the last save using the /loadlevel command.
 
 `[0] String` ws
 > Indicates the start of the world data.
@@ -982,15 +972,14 @@ Occurs when the world description is changed.
 > The world description.
 
 ### <a id="rm-roomVisible">"roomVisible"</a>
-Occurs when the world accessibility is changed.
+Occurs when the world accessibility is toggled.
 
 `[0] Boolean` Accessible
 > Value indicating whether the world is now accessible by other players.
 
-___
 
 ### <a id="rm-saved">"saved"</a>
-Occurs when you successfully saved world.
+Occurs when you saved the world.
 
 ### <a id="rm-say">"say"</a>
 Occurs when a player sends a chat message.
@@ -1018,14 +1007,14 @@ Contains information about chat message from before you joined the world.
 > The chat color of the sender.
 
 ### <a id="rm-show">"show"</a>
-Occurs when key deactivates or timed doors change their state.
+Occurs when a key deactivates or timed doors change their state.
 
 `[0] String` Key
 > The name of the key (or timed door).
 > *See [Keys](#model-keys).*
 
 ### <a id="rm-smileyGoldBorder">"smileyGoldBorder"</a>
-Occurs when someone enables or disables gold smiley border.
+Occurs when someone toggles the gold smiley border.
 
 `[0] Integer` Player Id
 > The player's identifier.
@@ -1033,10 +1022,9 @@ Occurs when someone enables or disables gold smiley border.
 `[1] Boolean` Gold Smiley Border
 > Value indicating whether the player is wearing gold smiley border.
 
-___
 
 ### <a id="rm-team">"team"</a>
-Occurs when someone changes their team.
+Occurs when a player changes their team.
 
 `[0] Integer` Player Id
 > The player's identifier.
@@ -1046,7 +1034,7 @@ Occurs when someone changes their team.
 > *See [Teams](#model-teams).*
 
 ### <a id="rm-tele">"tele"</a>
-Occurs when multiple players are teleported. This event gets raised for respawns of any kind, including death.
+Occurs when multiple players are teleported or respawns (including death.)
 
 `[0] Boolean` Reset
 > Value indicating whether the player's properties were reset.
@@ -1119,10 +1107,10 @@ Occurs when a sign block is placed in the world.
 ___
 
 ### <a id="rm-unfavorited">"unfavorited"</a>
-Occurs when you successfully un-favorite the world.
+Occurs when you un-favorite the world.
 
 ### <a id="rm-unliked">"unliked"</a>
-Occurs when you successfully un-like the world.
+Occurs when you un-like the world.
 
 ### <a id="rm-updatemeta">"updatemeta"</a>
 Occurs when world metadata is updated.
@@ -1143,9 +1131,8 @@ Occurs when world metadata is updated.
 > The amount of likes.
 
 ### <a id="rm-upgrade">"upgrade"</a>
-Occurs when the server version has increased.
+Occurs when the server has updated,
 
-___
 
 ### <a id="rm-worldReleased">"worldReleased"</a>
 Occurs when crew world has been released.
@@ -1169,7 +1156,7 @@ Occurs when a world portal is placed in the world.
 > The identifier of the player which placed this block.
 
 ### <a id="rm-write">"write"</a>
-Occurs when a non-player message is received. (System messages, etc.)
+Occurs when a non-player message is received (system messages, etc.)
 
 `[0] String` Title
 > The title of the message.
@@ -1177,7 +1164,6 @@ Occurs when a non-player message is received. (System messages, etc.)
 `[1] String` Text
 > The text of the message.
 
-___
 
 # <a id="send-messages">Send messages</a>
 
@@ -1209,7 +1195,6 @@ Sent to use auto-say message.
 > The auto-text message identifier.
 > *See [Auto Text](#model-auto-text).*
 
-___
 
 ### <a id="sm-b">"b"</a>
 Sent to place a block in the world.
@@ -1270,7 +1255,6 @@ Additional arguments:
 `[5] Integer` Sign Type
 > The sign type.
 
-___
 
 ### <a id="sm-c">"c"</a>
 Sent to collect a coin.
@@ -1288,7 +1272,7 @@ Sent to collect a coin.
 > The y coordinate of the coin's position.
 
 ### <a id="sm-caketouch">"caketouch"</a>
-Sent to touch a cake.
+Sent when a cake is touched.
 
 `[0] UInt` X
 > The x coordinate of the cake's position.
@@ -1324,7 +1308,6 @@ Sent to collect the gold crown.
 `[1] UInt` Y
 > The y coordinate of the crown's position.
 
-___
 
 ### <a id="sm-death">"death"</a>
 Sent to die.
@@ -1358,7 +1341,6 @@ ___
 ### <a id="sm-favorite">"favorite"</a>
 Sent to favorite the world.
 
-___
 
 ### <a id="sm-god">"god"</a>
 Sent to change the god mode state.
@@ -1366,7 +1348,6 @@ Sent to change the god mode state.
 `[0] Boolean` God Mode
 > Value indicating whether the god mode should be enabled.
 
-___
 
 ### <a id="sm-hologramtouch">"hologramtouch"</a>
 Sent to touch a hologram.
@@ -1377,7 +1358,6 @@ Sent to touch a hologram.
 `[1] UInt` Y
 > The y coordinate of the hologram's position.
 
-___
 
 ### <a id="sm-init">"init"</a>
 Sent to request initialization message.
@@ -1385,7 +1365,6 @@ Sent to request initialization message.
 ### <a id="sm-init2">"init2"</a>
 Sent to request initialization messages such as add, k, etc.
 
-___
 
 ### <a id="sm-key">"key"</a>
 Sent to change the edit key.
@@ -1396,7 +1375,6 @@ Sent to change the edit key.
 ### <a id="sm-kill">"kill"</a>
 Sent to kill the world.
 
-___
 
 ### <a id="sm-levelcomplete">"levelcomplete"</a>
 Sent to complete the world.
@@ -1410,7 +1388,6 @@ Sent to complete the world.
 ### <a id="sm-like">"like"</a>
 Sent to like the world.
 
-___
 
 ### <a id="sm-m">"m"</a>
 Sent to move.
@@ -1456,7 +1433,6 @@ Sent to move.
 ### <a id="sm-mod">"mod"</a>
 Sent to toggle moderator mode.
 
-___
 
 ### <a id="sm-name">"name"</a>
 Sent to change the world name.
@@ -1464,7 +1440,6 @@ Sent to change the world name.
 `[0] String` World Name
 > The world name.
 
-___
 
 ### <a id="sm-pressKey">"pressKey"</a>
 Sent to activate a key.
@@ -1488,8 +1463,6 @@ Sent to change the purple switch state.
 `[1] Integer` Enabled
 > Value indicating the state of the switch. 1 = active, 0 = disabled.
 
-___
-
 ### <a id="sm-rejectAddToCrew">"rejectAddToCrew"</a>
 Sent to reject add to crew request.
 
@@ -1508,7 +1481,6 @@ Sent to reset progress.
 `[1] UInt` Y
 > The y coordinate of the reset block's position.
 
-___
 
 ### <a id="sm-save">"save"</a>
 Sent to save the world.
@@ -1586,7 +1558,6 @@ Sent to enable or disable gold smiley border.
 `[0] Boolean` Gold Smiley Border
 > Value indicating whether the gold smiley border should be enabled.
 
-___
 
 ### <a id="sm-team">"team"</a>
 Sent to change team.
@@ -1612,7 +1583,6 @@ Sent to touch other player transferring effects.
 `[1] Integer` Effect
 > The effect identifier.
 
-___
 
 ### <a id="sm-unfavorite">"unfavorite"</a>
 Sent to un-favorite the world.
@@ -1620,7 +1590,6 @@ Sent to un-favorite the world.
 ### <a id="sm-unlike">"unlike"</a>
 Sent to un-like the world.
 
-___
 
 # <a id="models">Models</a>
 


### PR DESCRIPTION
- "a" or "an" must prefix words that begin with vowels
- removed extra white space on empty lines
- changed "identifier" to "id" because there are not many people who use [identifier](http://forums.everybodyedits.com/search.php?search_id=2032064424) on EE